### PR TITLE
added examples notebook

### DIFF
--- a/examples.ipynb
+++ b/examples.ipynb
@@ -1,0 +1,544 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "2aaacc7e-ac6e-4afa-8ffc-37c07346903a",
+   "metadata": {},
+   "source": [
+    "# polygonlite\n",
+    "\n",
+    "`polygonlite` is a lightweight, yet powerful (um, robust?) library for the usual Point, Edge and Polygon operations in Python.\n",
+    "\n",
+    "  - Point class which encompasses methods like project on edge, etc.\n",
+    "  - Edge class which has more powerful features like angle between edges, intersection of edges, etc.\n",
+    "  - Polygon class, which is still under construction."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "14937aee-6579-4ac5-8a1a-53fd851ffb6f",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from polygonlite import Polygon, Edge, Point"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cc9e4076-51ef-4f4d-b9c5-002c474b723d",
+   "metadata": {},
+   "source": [
+    "## Point\n",
+    "- Initialization"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "95e78abc-1718-4f0b-b1f5-83bae12d8524",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "origin = Point(0, 0)\n",
+    "point1 = Point([0, 1])\n",
+    "point2 = Point(x = 2, y = 0)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "61bd6add-88f4-46e1-867d-697b7a4718b6",
+   "metadata": {},
+   "source": [
+    "- Use cases"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "ac754f7e-783f-43d2-9bfd-cf433679e07f",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "[0, 0]"
+      ]
+     },
+     "execution_count": 3,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "origin.as_array()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "84658a5e-9cda-45ca-8d45-2c635fa4d88d",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "2.23606797749979"
+      ]
+     },
+     "execution_count": 4,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "point1.distance(point2)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "5af93bf5-8302-4580-988e-f9807c52aafa",
+   "metadata": {},
+   "source": [
+    "## Edge\n",
+    "- Initialization"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "b2c18485-ead4-46f2-8f02-26fd5e64e011",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "edge1 = Edge([0, 0], [5, 5])\n",
+    "edge2 = Edge([5, 0], [0, 5])\n",
+    "edge3 = Edge([5, 5], [10, 0])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "557d2187-9e34-4b0e-8df6-fc31af0a83a3",
+   "metadata": {},
+   "source": [
+    "- Use cases"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "dcd1c67f-9c4d-4c24-b7db-59bfee9409b5",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "[[0, 0], [5, 5]]"
+      ]
+     },
+     "execution_count": 6,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "edge1.as_array()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "90db60bb-81de-48f5-b3b1-db410770a41c",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "7.0710678118654755"
+      ]
+     },
+     "execution_count": 7,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "edge2.length()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "ccf613ea-88ed-46ff-8e6e-a1c951164592",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "-1.0"
+      ]
+     },
+     "execution_count": 8,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "edge3.slope()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "id": "6fe9f5bc-ca50-4dc7-814c-b71f4179dceb",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "[5, -5]"
+      ]
+     },
+     "execution_count": 9,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "edge3.vector()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "id": "6c88e256-b2de-4f63-a3dd-85c88630c070",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "10.0"
+      ]
+     },
+     "execution_count": 10,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "edge3.y_intercept()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "id": "3c80b040-ee51-46bb-8ba0-3eb8a513c194",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "True"
+      ]
+     },
+     "execution_count": 11,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "edge2.on_segment(origin)   # should be false"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "id": "479141d6-3b37-4b30-86ad-1d4f7672c54d",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "90.0"
+      ]
+     },
+     "execution_count": 12,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "edge1.angle_between(edge3)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "id": "2d468ef8-9e23-49a3-ae78-f7de74d30a15",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "True"
+      ]
+     },
+     "execution_count": 13,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "edge1.is_parallel(edge2)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "id": "befc98d1-1c92-443d-9f7a-d9c73210e99a",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "'collinear'"
+      ]
+     },
+     "execution_count": 14,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "edge1.intersect(edge3)   # always gives collinear"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "id": "f4433f84-1e8a-46e9-a1a2-746a7df3c663",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# these functions give an error (unsupported operand type(s) for /: 'Point' and 'int')\n",
+    "# point1.project(edge3)\n",
+    "# edge1.unit_vector()\n",
+    "# edge3.midpoint()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f0e6f22e-cb81-4098-b1ec-87ca2ac9cca8",
+   "metadata": {},
+   "source": [
+    "## Polygon\n",
+    "- Initialization"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 16,
+   "id": "47cf81da-389d-49a9-8818-f1056a9dd829",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "polygon = Polygon([[0, 0], [0, 5], [0, 10], [10, 10], [10, 0]])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "5c02ea1f-46cd-48c5-bd52-e3e7461e434a",
+   "metadata": {},
+   "source": [
+    "- Use cases"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 17,
+   "id": "3361a349-4f10-4ab3-8eb9-8997d516b898",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "[[0, 0], [0, 5], [0, 10], [10, 10], [10, 0]]"
+      ]
+     },
+     "execution_count": 17,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "polygon.as_array()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 18,
+   "id": "b9712f3d-c2bc-45f2-919b-b5fbdc8928f6",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "[[0, 0],[0, 10],[10, 10],[10, 0]]"
+      ]
+     },
+     "execution_count": 18,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "polygon.as_linked_list()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 19,
+   "id": "2761a159-8e5f-4512-afa3-558343a0a00f",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[[0, 0], [0, 10], [10, 10], [10, 0]]\n"
+     ]
+    }
+   ],
+   "source": [
+    "simplified = polygon.simplify()\n",
+    "print(simplified)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 20,
+   "id": "a597d07a-f590-42cc-9d51-a9a27ce9f564",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "[[10, 0], [10, 10], [0, 10], [0, 5], [0, 0]]"
+      ]
+     },
+     "execution_count": 20,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "polygon.flip()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 21,
+   "id": "e17ddb3b-ac8b-4686-8635-7c080fcade3e",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "100.0"
+      ]
+     },
+     "execution_count": 21,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "polygon.area()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 22,
+   "id": "8db85536-0089-45e4-a8bb-7fef9003482a",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "True"
+      ]
+     },
+     "execution_count": 22,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "polygon.is_clockwise()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 23,
+   "id": "93622534-a1aa-41bc-a942-edd9abb120bd",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "False"
+      ]
+     },
+     "execution_count": 23,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "polygon.is_anticlockwise()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 24,
+   "id": "9b7e2be3-cd45-45a1-b05f-88bd282fe4fd",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "True"
+      ]
+     },
+     "execution_count": 24,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "simplified.contains(origin)"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.8.9"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
Hello Pranav,
my first suggestion is to include the examples given in the readme into a Jupyter notebook. This makes the examples more interactive. A preview of the notebook can be looked at directly in Github.
In the next step, I suggest to remove the examples from the readme and refer to the example notebook. This makes the readme more concise.

Some methods on edges yielded errors, maybe I misused them.